### PR TITLE
Fix: Per server avatar does not update on remove

### DIFF
--- a/lib/extensions/guildmember.ts
+++ b/lib/extensions/guildmember.ts
@@ -57,7 +57,7 @@ export class FireMember extends GuildMember {
     // @ts-ignore
     super._patch(data);
 
-    if (data.avatar) this.avatar = data.avatar ?? null;
+    this.avatar = data.avatar ?? null;
   }
 
   avatarURL({


### PR DESCRIPTION
before it checked if the member had a per server avatar then update but that doesnt update if they remove the per server avatar among us 
me doing a little testing: https://canary.discord.com/channels/342506939340685312/688230724624580623/879446815936770049
so yeah yeah this fix i think idk i haven't tested it