### PR TITLE
Made quotes use server profile pictures and nicknames

### DIFF
--- a/lib/extensions/message.ts
+++ b/lib/extensions/message.ts
@@ -364,8 +364,8 @@ export class FireMessage extends Message {
     return await hook
       .send({
         content: content.length ? content : null,
-        username: this.author.toString().replace(/#0000/gim, ""),
-        avatarURL: this.author.displayAvatarURL({ size: 2048, format: "png" }),
+        username: `${this.member.nickname} (${this.author.toString().replace(/#0000/gim, "")})`,
+        avatarURL: this.member.displayAvatarURL({ size: 2048, format: "png" }),
         embeds: this.embeds.filter(
           (embed) =>
             !this.content?.includes(embed.url) && !this.isImageEmbed(embed)
@@ -434,8 +434,8 @@ export class FireMessage extends Message {
       .setColor(this.member?.displayColor || quoter.displayColor)
       .setTimestamp(this.createdAt)
       .setAuthor(
-        this.author.toString(),
-        this.author.displayAvatarURL({
+        `${this.member.nickname} (${this.author.toString()})`,
+        this.member.displayAvatarURL({
           size: 2048,
           format: "png",
           dynamic: true,


### PR DESCRIPTION
Quotes now use server profile pictures instead of global profile pictures. Quotes also contain the server-specific nickname.
Used profile picture and nickname are the ones in the origin server (server, where the original message was sent), not the destination of the quote.

Example:
<img width="202" alt="Discord_RoHQC9SYlj" src="https://user-images.githubusercontent.com/20520700/138147380-a46250bd-4a04-4149-8890-da29c5df2a64.png">

<img width="633" alt="Discord_FNBJE1621T" src="https://user-images.githubusercontent.com/20520700/138147420-e4e22547-cb0a-451a-8401-fdf96d14a9be.png">

