### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/util/clientutil.ts
+++ b/lib/util/clientutil.ts
@@ -212,15 +212,15 @@ export class Util extends ClientUtil {
   }
 
   addDashesToUUID = (uuid: string) =>
-    uuid.substr(0, 8) +
+    uuid.slice(0, 8) +
     "-" +
-    uuid.substr(8, 4) +
+    uuid.slice(8, 12) +
     "-" +
-    uuid.substr(12, 4) +
+    uuid.slice(12, 16) +
     "-" +
-    uuid.substr(16, 4) +
+    uuid.slice(16, 20) +
     "-" +
-    uuid.substr(20);
+    uuid.slice(20);
 
   getUserStatuses(shard?: number) {
     try {

--- a/src/commands/Utilities/deleteremind.ts
+++ b/src/commands/Utilities/deleteremind.ts
@@ -57,7 +57,7 @@ export default class RemindersDelete extends Command {
         name:
           reminderText.length < 95 - timeString.length
             ? `${reminder.get("reminder")} - ${timeString}`
-            : `${reminderText.substr(
+            : `${reminderText.slice(
                 0,
                 95 - timeString.length
               )}... - ${timeString}`,


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.